### PR TITLE
Upper Bounds Vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,50 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@yarnpkg/lockfile": "^1.1.0"
+        "@yarnpkg/lockfile": "^1.1.0",
+        "bleach": "^0.3.0"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/bleach": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/bleach/-/bleach-0.3.0.tgz",
+      "integrity": "sha512-umFRejCk6J4u3Q1LdhgFPKBkmhMGiU9kyTxmiCWZpcd2g7WRIM+HPaAHrEOOmO+U+0T3nHO2v9G0FsbmUNZxwg==",
+      "dependencies": {
+        "he": "0.4.x"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/he": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
+      "integrity": "sha512-wFn1JlcsgbcWEawQ6A1GztgNRRl6UyEtaARIDpAeH3c35T/9id/QQKvap1NAz6Yk2oKrKwXQZZFERS0tl9E0Jg==",
+      "bin": {
+        "he": "bin/he"
+      }
     }
   },
   "dependencies": {
     "@yarnpkg/lockfile": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+      "version": "1.1.0"
+    },
+    "bleach": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/bleach/-/bleach-0.3.0.tgz",
+      "integrity": "sha512-umFRejCk6J4u3Q1LdhgFPKBkmhMGiU9kyTxmiCWZpcd2g7WRIM+HPaAHrEOOmO+U+0T3nHO2v9G0FsbmUNZxwg==",
+      "requires": {
+        "he": "0.4.x"
+      }
+    },
+    "he": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-0.4.1.tgz",
+      "integrity": "sha512-wFn1JlcsgbcWEawQ6A1GztgNRRl6UyEtaARIDpAeH3c35T/9id/QQKvap1NAz6Yk2oKrKwXQZZFERS0tl9E0Jg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   ],
   "author": "GitHub",
   "license": "MIT",
-    "dependencies": {
-      "@yarnpkg/lockfile": "^1.1.0"
+  "dependencies": {
+    "@yarnpkg/lockfile": "^1.1.0",
+    "bleach": "^0.3.0"
   }
 }


### PR DESCRIPTION
There is no fix for the `bleach` library, Dependency Review should always fail.